### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,8 @@
 name: Build and Push Multi-Arch Docker Image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mstfknn/tor-proxy/security/code-scanning/1](https://github.com/mstfknn/tor-proxy/security/code-scanning/1)

The best way to fix the problem is to explicitly set the required permissions for the workflow's GITHUB_TOKEN by adding a `permissions` block. Since none of the steps shown need to write to the repo contents, issues, or pull requests, the minimal needed permission is `contents: read` to allow actions/checkout to work.  
To fix:  
- Add a `permissions:` block with `contents: read` at the workflow root (above `jobs:`), affecting all jobs in the workflow.  
- Edit only .github/workflows/docker-build.yml.  
- No imports, methods, or other definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
